### PR TITLE
build: version lock css_inline to 0.8.3

### DIFF
--- a/requirements/requirements-mandatory.txt
+++ b/requirements/requirements-mandatory.txt
@@ -1,3 +1,3 @@
 pynliner
 mock
-css_inline
+css_inline==0.8.3


### PR DESCRIPTION
# Task

N/A

# More Details

CSS Inline dropped the `musllinux aarch64` compilation in a [recent commit](https://github.com/Stranger6667/css-inline/commit/dab7908cce98ff96d144943dc18196c497703e4f) - meaning this broke the capacity-api build for Mac M1s. 

This PR simply locks the version to the previous one, that had a Mac M1 wheel available. 

# Comments

One alternative solution would be to install the `rust` toolchain on the capacity-api Docker image and compile it ourselves; but since we're already looking for alternatives for `django-mailcss` in [PE-3215](https://dray.atlassian.net/browse/PE-3215), this is a quicker fix.

