### PR TITLE
feat: remove css-inline upper bound limit

### DIFF
--- a/requirements/requirements-mandatory.txt
+++ b/requirements/requirements-mandatory.txt
@@ -1,3 +1,3 @@
 pynliner
 mock
-css_inline==0.8.3
+css_inline>=0.8.3

--- a/requirements/requirements-mandatory.txt
+++ b/requirements/requirements-mandatory.txt
@@ -1,3 +1,3 @@
 pynliner
 mock
-css_inline>=0.8.3
+css_inline


### PR DESCRIPTION
This was too strict with the library, and the locked version in here is not compatible with Python 3.12